### PR TITLE
feat: add application email service

### DIFF
--- a/underdogCountyProject/src/main/java/com/underdogCounty/underdogCountyProject/domain/application/service/ApplicationService.java
+++ b/underdogCountyProject/src/main/java/com/underdogCounty/underdogCountyProject/domain/application/service/ApplicationService.java
@@ -4,6 +4,9 @@ import com.underdogCounty.underdogCountyProject.domain.application.entity.Applic
 import com.underdogCounty.underdogCountyProject.domain.application.repository.ApplicationRepository;
 import com.underdogCounty.underdogCountyProject.domain.application.request.ApplicationCreationRequest;
 import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
 import javax.persistence.EntityNotFoundException;
@@ -13,6 +16,9 @@ import java.util.Optional;
 
 @Service
 public class ApplicationService {
+    @Autowired
+    private JavaMailSender javaMailSender;
+    private static final String FROM_ADDRESS = "rg970604@naver.com"; //여기에 대표자 이메일
 
     private final ApplicationRepository applicationRepository;
 
@@ -23,6 +29,22 @@ public class ApplicationService {
     public Application createApplication(ApplicationCreationRequest request){
         Application application = request.toEntity();
         BeanUtils.copyProperties(request,application);
+        //이메일설정
+        SimpleMailMessage message = new SimpleMailMessage();
+        //업체에서받는메일
+        message.setFrom(FROM_ADDRESS);
+        message.setTo(FROM_ADDRESS);
+        message.setSubject("[언더독 카운티]외주제작 신청서가 도착했습니다");
+        message.setText(
+                "이름: "+application.getName()+
+                "\n연락처: "+application.getPhonenumber()+
+                "\n이메일: "+application.getEmail()+
+                "\n내용: "+application.getContents());
+        javaMailSender.send(message);
+        //신청자가 받는 메일
+        message.setTo(application.getEmail());
+        message.setSubject("[언더독 카운티]요청하신 신청서 내용입니다");
+        javaMailSender.send(message);
         return applicationRepository.save(application);
     }
 


### PR DESCRIPTION
- [x] JavaMailSender 인터페이스를 활용해 신청서 생성 POST 요청시 이메일이 발송되도록 createApplication 기능을 수정했습니다
- [x] 외주 신청자 메일, 업체 메일쪽으로 같은 내용을 총 두 번 전송하도록 했습니다.

- issue : #24 